### PR TITLE
Fix LDAP attributes with a list of strings not populating, Closes #2

### DIFF
--- a/ldap2json.py
+++ b/ldap2json.py
@@ -27,28 +27,18 @@ def cast_to_dict(cid):
         if type(value) == bytes:
             out[key] = str(value)
         elif type(value) == list:
-            if len(value) == 1:
-                value = value[0]
-                if type(value) == bytes:
-                    out[key] = str(value)
-                elif type(value) == datetime.datetime:
-                    out[key] = value.strftime('%Y-%m-%d %T')
-                elif type(value) == datetime.timedelta:
+            newlist = []
+            for element in value:
+                if type(element) == bytes:
+                    newlist.append(str(element))
+                elif type(element) == datetime.datetime:
+                    newlist.append(element.strftime('%Y-%m-%d %T'))
+                elif type(element) == datetime.timedelta:
                     # Output format to change
-                    out[key] = value.seconds
+                    newlist.append(element.seconds)
                 else:
-                    out[key] = value
-            else:
-                newlist = []
-                for element in value:
-                    if type(element) == bytes:
-                        newlist.append(str(element))
-                    elif type(element) == datetime.datetime:
-                        newlist.append(element.strftime('%Y-%m-%d %T'))
-                    elif type(element) == datetime.timedelta:
-                        # Output format to change
-                        newlist.append(element.seconds)
-                out[key] = newlist
+                    newlist.append(str(element))
+            out[key] = newlist
         elif type(value) == datetime.datetime:
             out[key] = value.strftime('%Y-%m-%d %T')
         elif type(value) == datetime.timedelta:


### PR DESCRIPTION
Note that in making this fix, I also modified the cast_to_dict function to retain all LDAP object attributes of type list as lists. Before in the code if the list only had a single element, the cast_to_dict function would make the attribute just a single string, stripping the knowledge that this field should be a list which in turn would likely cause problems for anyone trying to write a parser for the output of this tool.