### PR TITLE
[bugfix] Add pycryptodome to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 impacket
 ldap3
 sectools
+pycryptodome


### PR DESCRIPTION
pycryptodome is needed to use Crypto.Hash
```python
from Crypto.Hash import MD4  # try with the Crypto library if present
^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'Crypto'
```